### PR TITLE
fix: specify python version we want

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
 
     - name: Install s3cmd
       run: python3 -m pip install s3cmd


### PR DESCRIPTION
python 3.9 seems to have broken s3cmd .. so for now....